### PR TITLE
add `meta` and `game_instance?` methods to game classes, instances, and Meta modules

### DIFF
--- a/assets/app/view/create_game.rb
+++ b/assets/app/view/create_game.rb
@@ -186,7 +186,7 @@ module View
     end
 
     def render_game_info
-      h(Game::GameMeta, game_class: @selected_game || selected_game)
+      h(Game::GameMeta, game: @selected_game || selected_game)
     end
 
     def mode_selector

--- a/assets/app/view/game/game_meta.rb
+++ b/assets/app/view/game/game_meta.rb
@@ -4,12 +4,6 @@ module View
   module Game
     class GameMeta < Snabberb::Component
       needs :game, default: nil
-      needs :game_class, default: nil
-
-      def initialize(*)
-        super
-        @game_class = @game.class unless defined? @game_class
-      end
 
       def render
         children = [h(:h3, 'Game Info')]
@@ -18,39 +12,39 @@ module View
         children.concat(render_designer)
         children.concat(render_implementer)
         children.concat(render_rule_links)
-        children.concat(render_optional_rules) if defined?(@game)
+        children.concat(render_optional_rules) if @game.game_instance?
         children.concat(render_more_info)
 
         h(:div, children)
       end
 
       def render_publisher
-        return [] unless @game_class::GAME_PUBLISHER
+        return [] unless @game.meta::GAME_PUBLISHER
 
         [h(:p, [
           'Published by ',
-          *Lib::Publisher.link_list(component: self, publishers: Array(@game_class::GAME_PUBLISHER)),
+          *Lib::Publisher.link_list(component: self, publishers: Array(@game.meta::GAME_PUBLISHER)),
         ])]
       end
 
       def render_designer
-        return [] unless @game_class::GAME_DESIGNER
+        return [] unless @game.meta::GAME_DESIGNER
 
-        [h(:p, "Designed by #{@game_class::GAME_DESIGNER}")]
+        [h(:p, "Designed by #{@game.meta::GAME_DESIGNER}")]
       end
 
       def render_implementer
-        return [] unless @game_class::GAME_IMPLEMENTER
+        return [] unless @game.meta::GAME_IMPLEMENTER
 
-        [h(:p, "Implemented by #{@game_class::GAME_IMPLEMENTER}")]
+        [h(:p, "Implemented by #{@game.meta::GAME_IMPLEMENTER}")]
       end
 
       def render_rule_links
-        unless @game_class::GAME_RULES_URL.is_a?(Hash)
-          return [h(:p, [h(:a, { attrs: { href: @game_class::GAME_RULES_URL, target: '_blank' } }, 'Rules')])]
+        unless @game.meta::GAME_RULES_URL.is_a?(Hash)
+          return [h(:p, [h(:a, { attrs: { href: @game.meta::GAME_RULES_URL, target: '_blank' } }, 'Rules')])]
         end
 
-        @game_class::GAME_RULES_URL.map do |desc, url|
+        @game.meta::GAME_RULES_URL.map do |desc, url|
           h(:p, [h(:a, { attrs: { href: url, target: '_blank' } }, desc)])
         end
       end
@@ -58,7 +52,7 @@ module View
       def render_optional_rules
         return [] if @game.optional_rules.empty?
 
-        used_optional_rules = @game_class::OPTIONAL_RULES.map do |o_r|
+        used_optional_rules = @game.meta::OPTIONAL_RULES.map do |o_r|
           next unless @game.optional_rules.include?(o_r[:sym])
 
           h(:p, " * #{o_r[:short_name]}: #{o_r[:desc]}")
@@ -69,9 +63,9 @@ module View
       end
 
       def render_more_info
-        return [] unless @game_class::GAME_INFO_URL
+        return [] unless @game.meta::GAME_INFO_URL
 
-        [h(:p, [h(:a, { attrs: { href: @game_class::GAME_INFO_URL, target: '_blank' } }, 'More info')])]
+        [h(:p, [h(:a, { attrs: { href: @game.meta::GAME_INFO_URL, target: '_blank' } }, 'More info')])]
       end
     end
   end

--- a/lib/engine/game/base.rb
+++ b/lib/engine/game/base.rb
@@ -328,6 +328,20 @@ module Engine
         meta_module.constants.each do |const|
           const_set(const, meta_module.const_get(const))
         end
+
+        const_set(:META, meta_module)
+      end
+
+      def self.meta
+        self::META
+      end
+
+      def meta
+        self.class.meta
+      end
+
+      def game_instance?
+        true
       end
 
       def initialize(names, id: 0, actions: [], pin: nil, strict: false, optional_rules: [], user: nil)

--- a/lib/engine/game/meta.rb
+++ b/lib/engine/game/meta.rb
@@ -53,6 +53,14 @@ module Engine
               part.sub(/^G/, 'g_').gsub(/(.)([A-Z]+)/, '\1_\2').downcase
             end
         end
+
+        def meta
+          self
+        end
+
+        def game_instance?
+          false
+        end
       end
     end
   end


### PR DESCRIPTION
with any game-ish thing (subclass of `Engine::Game::Base`, an instance of such a
class, or any `Engine::Game::*::Meta`), quickly get the associated Meta module
with `.meta`, and quickly find out if it's an instance of `Engine::Game::Base`
with `.game_instance?`

![Screenshot 2021-03-15 092032](https://user-images.githubusercontent.com/1045173/111177399-cb15ce00-856f-11eb-9d29-7899e9db4965.png)